### PR TITLE
Throw on invalid predicate even if array is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,15 @@ module.exports = function (arr, predicate, ctx) {
 		return arr.findIndex(predicate, ctx);
 	}
 
+	if (typeof predicate !== 'function') {
+		throw new TypeError('predicate must be a function');
+	}
+
 	var list = Object(arr);
 	var len = list.length;
 
 	if (len === 0) {
 		return -1;
-	}
-
-	if (typeof predicate !== 'function') {
-		throw new TypeError('predicate must be a function');
 	}
 
 	for (var i = 0; i < len; i++) {


### PR DESCRIPTION
For consistency with V8:

```
> [].findIndex(null)
TypeError: null is not a function
    at Array.findIndex (native)
    at repl:1:4
    at REPLServer.defaultEval (repl.js:252:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:417:12)
    at emitOne (events.js:82:20)
    at REPLServer.emit (events.js:169:7)
    at REPLServer.Interface._onLine (readline.js:210:10)
    at REPLServer.Interface._line (readline.js:549:8)
```
